### PR TITLE
更新時にパスワード認証する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (9.7.6)
       execjs
+    bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
@@ -236,6 +237,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -1,0 +1,12 @@
+.notifications {
+  color: white;
+  text-align: center;
+
+  .notice {
+    background-color: lightBlue;
+  }
+
+  .alert {
+    background-color: orange;
+  }
+}

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -42,7 +42,7 @@ class TeamsController < ApplicationController
 
   def update
     respond_to do |format|
-      if @team.update(team_params)
+      if @team.authenticate(team_params[:password]) && @team.update(team_params)
         format.html { redirect_to @team, notice: '更新しました' }
         format.json { render :show, status: :ok, location: @team }
       else

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -41,21 +41,20 @@ class TeamsController < ApplicationController
   end
 
   def update
-    respond_to do |format|
-      if @team.authenticate(team_params[:password]) && @team.update(team_params)
-        format.html { redirect_to @team, notice: '更新しました' }
-        format.json { render :show, status: :ok, location: @team }
-      else
-        format.html { render :edit }
-        format.json { render json: @team.errors, status: :unprocessable_entity }
-      end
+    if @team.authenticate(team_params[:password])
+      @team.update(team_params)
+      redirect_to @team, notice: '投稿を更新しました'
+    else
+      redirect_to edit_team_path, alert: 'パスワードが一致しません'
     end
   end
 
   def destroy
-    @team.destroy
-    respond_to do |format|
-      format.html { redirect_to root_url, notice: '削除しました'}
+    if @team.authenticate(team_params[:password])
+      @team.destroy
+      redirect_to root_url, notice: '削除しました'
+    else
+      redirect_to edit_team_path, alert: 'パスワードが一致しません'
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,4 +1,5 @@
 class Team < ApplicationRecord
+  has_secure_password
   has_many :team_ranks
   has_many :team_game_types
   has_many :team_champions

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,0 +1,3 @@
+.notifications
+  - flash.each do |key, value|
+    = content_tag(:div, value, class: key)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,4 +24,5 @@
           %li
             %a{:href => "mobile.html"}
               %i.material-icons more_vert
+    = render 'layouts/flash'
     = yield

--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -39,6 +39,7 @@
   = f.password_field :password
 
   - if action == "create"
-    = f.submit "募集する",  class: "waves-effect waves-light btn"
+    = f.submit "募集する", class: "waves-effect waves-light btn"
   - else
     = f.submit "更新する", class: "waves-effect waves-light btn"
+    = f.submit "削除する", class: "waves-effect waves-light btn"

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -1,2 +1,1 @@
-= render 'form', team: @team, action: "update"
-
+= render 'form', team: @team, action: "update", action: "destroy"

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -62,4 +62,3 @@
 
           .card-action
             = link_to"編集", edit_team_path
-            = link_to"削除", @team, method: :delete

--- a/db/migrate/20200506063936_add_password_digest_to_teams.rb
+++ b/db/migrate/20200506063936_add_password_digest_to_teams.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToTeams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :teams, :password_digest, :string
+  end
+end

--- a/db/migrate/20200506105527_remove_password_from_teams.rb
+++ b/db/migrate/20200506105527_remove_password_from_teams.rb
@@ -1,0 +1,5 @@
+class RemovePasswordFromTeams < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :teams, :password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_25_140852) do
+ActiveRecord::Schema.define(version: 2020_05_06_105527) do
 
   create_table "champions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -78,9 +78,9 @@ ActiveRecord::Schema.define(version: 2020_04_25_140852) do
     t.string "summoner_name"
     t.string "skype"
     t.string "discord"
-    t.string "password", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "password_digest"
   end
 
   add_foreign_key "team_champions", "champions"


### PR DESCRIPTION
closed #21 

**内容**
http://localhost:3000/teams/:id/edit
編集画面のパスワードは認証ではなく更新用になっている
**問題**
投稿したユーザのみが編集/削除可能にしたいが、現在は全てのユーザが編集可能になってしまっているため修正

**修正部分**
- パスワード認証する必要があるので、カラムに`password_digest`を追加
- `password`カラムは`password_digest`で代用可能のため削除
- `bcrypt`の導入
- `team/:id/`にある削除ボタンを編集画面に持っていく