### PR TITLE
Gemのrails-i18nを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'haml-rails'
 
+gem 'rails-i18n'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.2.2)
       actionpack (= 6.0.2.2)
       activesupport (= 6.0.2.2)
@@ -251,6 +254,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.1)
+  rails-i18n
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,8 @@ module LolVc
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end


### PR DESCRIPTION
closed #13

i18nを導入するため`gem 'rails-i18n'`をインストールし、
複数ロケールファイルが読み込まれるように`config/application.rb`に記述した。