### PR TITLE
Use Riot games Api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'addressable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug

--- a/app/assets/stylesheets/teams.scss
+++ b/app/assets/stylesheets/teams.scss
@@ -36,6 +36,11 @@
   padding: 20px;
 }
 
+.circle.responsive-img {
+  width: 50px;
+  height: auto;
+}
+
 .team-body {
   padding: 10px 20px;
 }

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -25,15 +25,12 @@ class TeamsController < ApplicationController
 
   def create
     @team = Team.new(team_params)
-
-    respond_to do |format|
-      if @team.save
-        format.html { redirect_to @team, notice: '募集しました' }
-        format.json { render :show, status: :created, location: @team }
-      else
-        format.html { render :new }
-        format.json { render json: @team.errors, status: :unprocessable_entity }
-      end
+    @team.profile_image << @team.profile_img(@team.summoner_name)
+    if @team.summoner_name.present?
+      @team.save
+      redirect_to @team, notice: '投稿しました'
+    else
+      redirect_to new_team_path, alert: 'SummonerNameを入力してください'
     end
   end
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -25,7 +25,7 @@ class TeamsController < ApplicationController
 
   def create
     @team = Team.new(team_params)
-    @team.profile_image << @team.profile_img(@team.summoner_name)
+    @team.profile_image = @team.profile_img(@team.summoner_name)
     if @team.summoner_name.present?
       @team.save
       redirect_to @team, notice: '投稿しました'

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,4 +1,11 @@
+# frozen_string_literal: true
+require 'net/http'
+require 'uri'
+require 'json'
+
 class Team < ApplicationRecord
+  API_KEY = 'RGAPI-abc18254-19a3-4eee-a828-d0243559a545'
+
   has_secure_password
   has_many :team_ranks
   has_many :team_game_types
@@ -22,4 +29,13 @@ class Team < ApplicationRecord
   scope :game_type_like, -> (game_type) { joins(:game_types).where(game_types: {id: game_type}) if game_type[1].present? }
   scope :rank_like, -> (rank) { joins(:ranks).where(ranks: {id: rank}) if rank[1].present? }
   scope :champion_like, -> (champion) { joins(:champions).where(champions: {id: champion}) if champion[1].present? }
+
+	def profile_img(summoner_name)
+		binding.pry
+		uri = URI.parse("https://jp1.api.riotgames.com/lol/summoner/v4/summoners/by-name/#{summoner_name}?api_key=#{API_KEY}")
+		binding.pry
+		return_data = Net::HTTP.get(uri)
+		summoner_data = JSON.parse(return_data)
+		summoner_data["profileIconId"]
+	end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,6 +2,8 @@
 require 'net/http'
 require 'uri'
 require 'json'
+require "addressable/uri"
+
 
 class Team < ApplicationRecord
   API_KEY = 'RGAPI-abc18254-19a3-4eee-a828-d0243559a545'
@@ -30,10 +32,9 @@ class Team < ApplicationRecord
   scope :rank_like, -> (rank) { joins(:ranks).where(ranks: {id: rank}) if rank[1].present? }
   scope :champion_like, -> (champion) { joins(:champions).where(champions: {id: champion}) if champion[1].present? }
 
-	def profile_img(summoner_name)
-		binding.pry
-		uri = URI.parse("https://jp1.api.riotgames.com/lol/summoner/v4/summoners/by-name/#{summoner_name}?api_key=#{API_KEY}")
-		binding.pry
+  def profile_img(summoner_name)
+
+		uri = Addressable::URI.parse("https://jp1.api.riotgames.com/lol/summoner/v4/summoners/by-name/#{summoner_name}?api_key=#{API_KEY}")
 		return_data = Net::HTTP.get(uri)
 		summoner_data = JSON.parse(return_data)
 		summoner_data["profileIconId"]

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+
   %body
     %nav
       .nav-wrapper

--- a/app/views/teams/_teams.html.haml
+++ b/app/views/teams/_teams.html.haml
@@ -11,6 +11,7 @@
             .summoner_name
               %strong= t(:summoner_name)
               %br/
+              %img.circle.responsive-img{ src: "http://ddragon.leagueoflegends.com/cdn/6.5.1/img/profileicon/#{team.profile_image}.png", alt: "profile_img"}
               %a{ href: "https://jp.op.gg/summoner/userName=#{team.summoner_name}" } #{ team.summoner_name }
 
             .tags

--- a/db/migrate/20200607165324_add_profile_image_to_teams.rb
+++ b/db/migrate/20200607165324_add_profile_image_to_teams.rb
@@ -1,0 +1,5 @@
+class AddProfileImageToTeams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :teams, :profile_image, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_09_142622) do
+ActiveRecord::Schema.define(version: 2020_06_07_165324) do
+
   create_table "champions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
@@ -80,6 +81,7 @@ ActiveRecord::Schema.define(version: 2020_05_09_142622) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
+    t.integer "profile_image"
   end
 
   add_foreign_key "team_champions", "champions"


### PR DESCRIPTION
**内容**
Riot games Apiを使う

**変更**
- ユーザのプロフィール画像をApiを通じて取得する
- 日本語サモナー名のユーザのデータを取得するためには、日本語のエンコードが必要なのでGemを追加する（URI moduleにあるencodeメソッドは非推奨っぽい）
https://github.com/sporkmonger/addressable

- ユーザのプロフィール画像データを保持するためにカラムを追加(profile_image)
