### PR TITLE
🐛Fix enable delete button

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -38,21 +38,19 @@ class TeamsController < ApplicationController
   end
 
   def update
-    if @team.authenticate(team_params[:password])
+    if params[:update] && @team.authenticate(team_params[:password])
       @team.update(team_params)
       redirect_to @team, notice: '投稿を更新しました'
+    elsif params[:delete] && @team.authenticate(team_params[:password])
+      self.destroy
     else
       redirect_to edit_team_path, alert: 'パスワードが一致しません'
     end
   end
 
   def destroy
-    if @team.authenticate(team_params[:password])
       @team.destroy
       redirect_to root_url, notice: '削除しました'
-    else
-      redirect_to edit_team_path, alert: 'パスワードが一致しません'
-    end
   end
 
   def search

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -9,9 +9,9 @@ class Team < ApplicationRecord
   API_KEY = 'RGAPI-abc18254-19a3-4eee-a828-d0243559a545'
 
   has_secure_password
-  has_many :team_ranks
-  has_many :team_game_types
-  has_many :team_champions
+  has_many :team_ranks, dependent: :destroy
+  has_many :team_game_types, dependent: :destroy
+  has_many :team_champions, dependent: :destroy
   has_many :game_types, through: :team_game_types
   has_many :ranks, through: :team_ranks
   has_many :champions, through: :team_champions

--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -41,5 +41,5 @@
   - if action == "create"
     = f.submit "募集する", class: "waves-effect waves-light btn"
   - else
-    = f.submit "更新する", class: "waves-effect waves-light btn"
-    = f.submit "削除する", class: "waves-effect waves-light btn"
+    = f.submit "更新する", name: 'update', class: "waves-effect waves-light btn"
+    = f.submit "削除する", name: 'destroy', class: "waves-effect waves-light btn"

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -1,1 +1,1 @@
-= render 'form', team: @team, action: "update", action: "destroy"
+= render 'form', team: @team, action: "update"


### PR DESCRIPTION
**内容**
フォーム画面の削除ボタンが`destroy`ではなく、`update`になっていた件

**原因**
`app/views/teams/_form.html.haml`がレンダリングされるファイルは以下2つ

- `app/views/teams/edit.html.haml`
  - 編集時 (actionはupdateになる)
- `app/views/teams/new.html.haml`
  - 新規作成時 (actionはnewになる)

編集時のactionがupdateになるため、destroyとして動作しなかった。

**変更内容**
1フォームにつき、1actionが一般的なのでフォーム内に2つactionが違うボタンを設置する場合は
指定したactionのあるコントローラ内で制御する必要がある。

updateアクションにdestroyの動作を入れてしまうのは美しくはないけど、一旦こんな感じで変更した

nameを付与してパラメータとして渡せる用に設定
```
    = f.submit "更新する", name: 'update', class: "waves-effect waves-light btn"
    = f.submit "削除する", name: 'delete', class: "waves-effect waves-light btn" 
```


```
def update
    if @team.authenticate(team_params[:password])
    if params[:update] && @team.authenticate(team_params[:password])
      @team.update(team_params)
      redirect_to @team, notice: '投稿を更新しました'
    elsif params[:delete] && @team.authenticate(team_params[:password]) #destroyパラメータがあればdestroyアクションに遷移する
      self.destroy
    else
      redirect_to edit_team_path, alert: 'パスワードが一致しません'
    end
  end
```