### PR TITLE
✨Add gender column

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -65,7 +65,7 @@ class TeamsController < ApplicationController
   end
 
   def team_params
-    params.require(:team).permit(:summoner_name, :discord, :skype, :body, :password, rank_ids: [], game_type_ids: [], champion_ids: [], lane_ids: [])
+    params.require(:team).permit(:summoner_name, :gender, :discord, :skype, :body, :password, rank_ids: [], game_type_ids: [], champion_ids: [], lane_ids: [])
   end
 
   def set_team

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -22,6 +22,8 @@ class Team < ApplicationRecord
   validates :body, presence: true
   validates :summoner_name, presence: true
 
+  enum gender: { man: 0, wonman: 1, unknown: 2 }
+
   scope :search, -> (search_params) do
     return if search_params.blank?
 

--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -1,14 +1,14 @@
 = form_for @team, url: {controller: "teams", action: action }, html: {class: "team_form"} do |f|
   = f.label t('.rank_id')
   %br/
+  = f.label t('.summoner_name')
+  = f.text_field :summoner_name, placeholder:'サモナー名'
+
+  %br/
   = f.collection_check_boxes :rank_ids, @ranks, :id, :name do |r|
     = r.label do
       = r.check_box
       %span= r.text
-
-  %br/
-  = f.label t('.summoner_name')
-  = f.text_field :summoner_name, placeholder:'サモナー名'
 
   = f.label t('.game_type')
   %br/

--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -1,15 +1,31 @@
 = form_for @team, url: {controller: "teams", action: action }, html: {class: "team_form"} do |f|
-  = f.label t('.rank_id')
   %br/
   = f.label t('.summoner_name')
   = f.text_field :summoner_name, placeholder:'サモナー名'
 
+  %br/
+  = f.label t('.gender')
+  %br/
+  = f.label :gender_man, :man do
+    = f.radio_button :gender, :man, class: "with-gap"
+    %span= '男性'
+  = f.label :gender_woman, :woman do
+    = f.radio_button :gender, :woman, class: "with-gap"
+    %span= '女性'
+  = f.label :gender_unknown, :unknown do
+    = f.radio_button :gender, :unknown, class: "with-gap"
+    %span= '不明'
+
+
+  %br/
+  = f.label t('.rank_id')
   %br/
   = f.collection_check_boxes :rank_ids, @ranks, :id, :name do |r|
     = r.label do
       = r.check_box
       %span= r.text
 
+  %br/
   = f.label t('.game_type')
   %br/
   = f.collection_check_boxes :game_type_ids, @game_types, :id, :name do |r|

--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -1,5 +1,5 @@
 = form_for @team, url: {controller: "teams", action: action }, html: {class: "team_form"} do |f|
-  = f.label :rank_id
+  = f.label t('.rank_id')
   %br/
   = f.collection_check_boxes :rank_ids, @ranks, :id, :name do |r|
     = r.label do
@@ -7,10 +7,10 @@
       %span= r.text
 
   %br/
-  = f.label :summoner, t(:summoner_name)
+  = f.label t('.summoner_name')
   = f.text_field :summoner_name, placeholder:'サモナー名'
 
-  = f.label :game_type, t(:game_type)
+  = f.label t('.game_type')
   %br/
   = f.collection_check_boxes :game_type_ids, @game_types, :id, :name do |r|
     = r.label do
@@ -18,7 +18,7 @@
       %span= r.text
 
   %br/
-  = f.label :lane, t(:lane)
+  = f.label t('.lane_type')
   %br/
   = f.collection_check_boxes :lane_ids, @lanes, :id, :name do |r|
     = r.label do
@@ -26,13 +26,13 @@
       %span= r.text
 
   %br/
-  = f.label :discord, t(:discord)
+  = f.label t('.discord')
   = f.text_field :discord, placeholder:'Discord ID'
-  = f.label :skype, t(:skype)
+  = f.label t('.skype')
   = f.text_field :skype, placeholder:'Skype ID'
-  = f.label :body, t(:body)
+  = f.label t('.body')
   = f.text_area :body, placeholder:'メッセージ'
-  = f.label :password, t(:password)
+  = f.label t('.password')
   = f.password_field :password, placeholder:'パスワード'
 
   - if action == "create"

--- a/config/locales/views/teams/ja.yml
+++ b/config/locales/views/teams/ja.yml
@@ -13,3 +13,13 @@ ja:
       teams:
         opgg: OP.GG
         edit: 編集する
+
+      form:
+        rank_id:       ランク
+        summoner_name: サモナーID
+        game_type:     ゲーム
+        lane_type:     レーン
+        discord:       discord
+        skype:         skype
+        body:          メッセージ
+        password:      パスワード

--- a/config/locales/views/teams/ja.yml
+++ b/config/locales/views/teams/ja.yml
@@ -16,6 +16,7 @@ ja:
 
       form:
         rank_id:       ランク
+        gender:        性別
         summoner_name: サモナーID
         game_type:     ゲーム
         lane_type:     レーン

--- a/db/migrate/20200929142939_add_gender_to_teams.rb
+++ b/db/migrate/20200929142939_add_gender_to_teams.rb
@@ -1,5 +1,5 @@
 class AddGenderToTeams < ActiveRecord::Migration[6.0]
   def change
-    add_column :teams, :gender, :integer
+    add_column :teams, :gender, :integer, default: 2
   end
 end

--- a/db/migrate/20200929142939_add_gender_to_teams.rb
+++ b/db/migrate/20200929142939_add_gender_to_teams.rb
@@ -1,0 +1,5 @@
+class AddGenderToTeams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :teams, :gender, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 2020_09_29_142939) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
     t.integer "profile_image"
-    t.integer "gender"
+    t.integer "gender", default: 2
   end
 
   add_foreign_key "team_champions", "champions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_20_041943) do
+ActiveRecord::Schema.define(version: 2020_09_29_142939) do
 
   create_table "champions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 2020_09_20_041943) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
     t.integer "profile_image"
+    t.integer "gender"
   end
 
   add_foreign_key "team_champions", "champions"


### PR DESCRIPTION
## 内容
投稿フォームに性別を選択するボタンを追加する

## 変更点
- teamsテーブルにgenderカラムを追加
    - genderカラムはenumを使って管理する
```bash
[4] pry(main)> Team.genders
=> {"man"=>0, "wonman"=>1, "unknown"=>2}
```

- 投稿フォームにラジオボタンを設定する
    - Materializeを使うとRailsヘルパーを使うだけでは、ラジオボタンは表示されない為`span`を入れてあげる必要がある（ここかなり詰まった）
```app/views/teams/_form.html.haml
  = f.label :gender_man, :man do
    = f.radio_button :gender, :man, class: "with-gap"
    %span= '男性'
```

## 補足

```bash
[3] pry(main)> Team.find(2)
   (1.1ms)  SET NAMES utf8mb4,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
  Team Load (0.8ms)  SELECT `teams`.* FROM `teams` WHERE `teams`.`id` = 2 LIMIT 1
=> #<Team:0x0000564aab0ad4e8
 id: 2,
 body: "テスト",
 summoner_name: "222cm",
 skype: "",
 discord: "",
 created_at: Tue, 06 Oct 2020 14:28:52 UTC +00:00,
 updated_at: Tue, 06 Oct 2020 14:28:52 UTC +00:00,
 password_digest: [FILTERED],
 profile_image: 745,
 gender: "unknown">
```
コンソールでTeamオブジェクトにgenderカラムが追加されていることを確認した。

```bash
web_1  | Processing by TeamsController#create as HTML
web_1  |   Parameters: {"authenticity_token"=>"I5hhzpM//y1R00VXsAHOiZWPIUroneBurzJpHx/Nh815HiQ/V+LiSXtPnHbH3bEkYmUwVyH1GtaoWXjV83P72g==", "team"=>{"summoner_name"=>"222cm", "gender"=>"unknown", "rank_ids"=>["", "1"], "game_type_ids"=>["", "1"], "lane_ids"=>["", "1"], "discord"=>"", "skype"=>"", "body"=>"テスト", "password"=>"[FILTERED]"}, "commit"=>"募集する", "expect"=>:index}
```
また投稿作成時にもパラメータが渡されているのが確認できる。


このPRがマージされたら、ローカル環境で一度`docker-compose run web bundle exec rails db:migrate`を実行してください