### PR TITLE
fixed title color

### DIFF
--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -46,9 +46,12 @@
 
   %br/
   = f.label t('.discord')
+  %br/
   = f.text_field :discord, placeholder:'Discord ID'
+  %br/
   = f.label t('.skype')
   = f.text_field :skype, placeholder:'Skype ID'
+  %br/
   = f.label t('.body')
   = f.text_area :body, placeholder:'メッセージ'
   = f.label t('.password')


### PR DESCRIPTION
I add "%br/" between the items on the posting page.
Now you can see the titles of the items does not change the color anymore.
If you suggest me to make the item title color change correctly when you select the form, I would like to create an issue separately.

I'm sorry for the delay because I was fighting with a weird error.
fix #83


