### PR TITLE
✨Change access to https

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
1. Install PointDNS.
2.  ALIAS and CNAME wrote DNS Target value in PointDNS Mydomains pages.
3. type command.
```shell
rutko@rutkonoMBP LoL-VC % heroku certs:auto:enable
Enabling Automatic Certificate Management... starting. See status with heroku certs:auto or wait until active with heroku certs:auto:wait
=== Your certificate will now be managed by Heroku.  Check the status by running heroku certs:auto.
```

## FIY
![スクリーンショット 2020-12-06 0 30 42](https://user-images.githubusercontent.com/26114407/101247050-4e967680-375a-11eb-896d-c232f3b57191.png)

![スクリーンショット 2020-12-06 0 38 00](https://user-images.githubusercontent.com/26114407/101247186-50ad0500-375b-11eb-8266-3b552e6c4d45.png)
