### PR TITLE
fixed the cutting off tags in the posts

### DIFF
--- a/app/assets/stylesheets/teams.scss
+++ b/app/assets/stylesheets/teams.scss
@@ -67,6 +67,7 @@
 .tags {
   padding: 10px 20px;
   display: inline-flex;
+  flex-wrap: wrap;
 }
 
 .message {


### PR DESCRIPTION
Summary
The tags were cutting off in the posts.
We added flex-wrap:wrap in line 70 to fix this issue.

Result
Even if all tags are selected on the post screen, they are now displayed in multiple lines.