### PR TITLE
remove op.gg ubtton

### DIFF
--- a/app/views/teams/_team.html+mobile.haml
+++ b/app/views/teams/_team.html+mobile.haml
@@ -84,8 +84,5 @@
 
             .card-action
               .waves-effect.waves-light.btn-small
-                .material-icons.right launch
-                = link_to(t('.opgg'), "https://jp.op.gg/summoner/userName=#{team.summoner_name}")
-              .waves-effect.waves-light.btn-small
                 = link_to(t('.edit'), edit_team_path(team))
 = paginate teams

--- a/app/views/teams/_teams.html.haml
+++ b/app/views/teams/_teams.html.haml
@@ -78,8 +78,5 @@
 
             .card-action
               .waves-effect.waves-light.btn-small
-                .material-icons.right launch
-                = link_to(t('.opgg'), "https://jp.op.gg/summoner/userName=#{team.summoner_name}")
-              .waves-effect.waves-light.btn-small
                 = link_to(t('.edit'), edit_team_path(team))
 = paginate teams


### PR DESCRIPTION
### Issue
closed #146 

### Summary
サモナー名からOP.GGに遷移できるのならば、カードfooterのOP.GGボタンは不要

### Change
[編集する]ボタンの左隣の[OP.GG]ボタンを削除
