### PR TITLE
$ docker-compose run --rm web bundle install でGemの更新をできるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 RUN NODE_ENV=development yarn install
 
 WORKDIR /myapp
-COPY Gemfile /myapp/Gemfile
-COPY Gemfile.lock /myapp/Gemfile.lock
+ADD Gemfile /myapp/Gemfile
+ADD Gemfile.lock /myapp/Gemfile.lock
 RUN gem install bundler
 RUN bundle install
 COPY . /myapp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/myapp
+      - bundle:/bundle
     ports:
       - "3000:3000"
     depends_on:
@@ -23,4 +24,6 @@ services:
     command: bundle exec rails server -b 0.0.0.0
 volumes:
   mysql-data:
+    driver: local
+  bundle:
     driver: local


### PR DESCRIPTION
## Summary

Gemの更新が走るたびに`$ docker-compose build`するのは作業効率悪いので
`$ docker-compose run --rm web bundle install `で更新できるように修正した。

対応は以下

- docker-compose run web bundle installでvolumeを更新する。
- volumeを一回削除し再度作成することによって、volumeの中身を/usr/local/bundleと同じにする。

## FIY

Gemの更新はbundle installした内容をvolumeを使用してデータを永続化している。
`$ docker-compose build` ではvolumeと紐付かないので更新される
`$ docker-compose run`はvolumeと紐付く

Gemfileを更新した際に以下の部分をやり直す必要がある
https://github.com/LoL-pj/LoL-VC/blob/923122f87cb8e2d821241a62f78736bd7d2242b1/Dockerfile#L11-L12